### PR TITLE
fix: dump non ascii encoding issue

### DIFF
--- a/lkml2cube/main.py
+++ b/lkml2cube/main.py
@@ -39,7 +39,7 @@ def cubes(
     cube_def = generate_cube_joins(cube_def, lookml_model)
     
     if printonly:
-        typer.echo(yaml.dump(cube_def))
+        typer.echo(yaml.dump(cube_def, allow_unicode=True))
         return
     
     write_files(cube_def, outputdir=outputdir)
@@ -66,7 +66,7 @@ def views(
     cube_def = parse_explores(lookml_model)
 
     if printonly:
-        typer.echo(yaml.dump(cube_def))
+        typer.echo(yaml.dump(cube_def, allow_unicode=True))
         return
     
     write_files(cube_def, outputdir=outputdir)

--- a/lkml2cube/parser/loader.py
+++ b/lkml2cube/parser/loader.py
@@ -48,7 +48,7 @@ def file_loader(file_path_input, namespace=None):
 def write_single_file(cube_def: dict, outputdir: str, subdir: str = 'cubes', file_name: str = 'my_cubes.yml'):
 
     f = open(join(outputdir, subdir, file_name), 'w')
-    f.write(yaml.dump(cube_def))
+    f.write(yaml.dump(cube_def, allow_unicode=True))
     f.close()
 
 


### PR DESCRIPTION
- avoid encoding non-ASCII characters such as Japanese and other multi-byte characters during the dump process