### PR TITLE
Emit explore joins on the LEFT-side cube

### DIFF
--- a/lkml2cube/parser/explores.py
+++ b/lkml2cube/parser/explores.py
@@ -139,23 +139,37 @@ def traverse_graph(join_paths, cube_left, cube_right):
 
 def generate_cube_joins(cube_def, lookml_model):
     """Generate cube join definitions from LookML explores.
-    
+
+    Each LookML join is emitted on the cube it joins **from** (the cube
+    appearing alongside the target in `sql_on`), pointing at the join
+    target, with the LookML relationship value preserved verbatim.
+
+    This matches Cube's convention that "the cube which defines the join
+    serves as a main table" (the LEFT side of the LEFT JOIN). Declaring on
+    the target cube instead would silently flip cardinality, since the
+    LookML relationship is described from the explore's perspective.
+    Cube traverses joins bidirectionally via Dijkstra, so a single-sided
+    declaration is sufficient — declaring on both sides would produce
+    redundant joins (see https://cube.dev/docs/product/data-modeling/reference/joins).
+
     Args:
         cube_def (dict): Existing cube definition to modify.
         lookml_model (dict): LookML model containing explores with joins.
-    
+
     Returns:
         dict: Updated cube definition with join information added to cubes.
-    
+
     Raises:
         Exception: If cube referenced in explores is not found.
-    
+
     Example:
         >>> cube_def = {'cubes': [{'name': 'orders'}, {'name': 'customers'}]}
         >>> lookml_model = {'explores': [{'joins': [{'name': 'customers', 'sql_on': '${orders.customer_id} = ${customers.id}', 'relationship': 'many_to_one'}]}]}
         >>> updated_def = generate_cube_joins(cube_def, lookml_model)
-        >>> print(updated_def['cubes'][1]['joins'][0]['name'])
-        'orders'
+        >>> print(updated_def['cubes'][0]['joins'][0]['name'])
+        customers
+        >>> print(updated_def['cubes'][0]['joins'][0]['relationship'])
+        many_to_one
     """
     if "explores" not in lookml_model or not lookml_model["explores"]:
         return cube_def
@@ -165,43 +179,50 @@ def generate_cube_joins(cube_def, lookml_model):
 
         for join_element in explore["joins"]:
             try:
-                cube_right = join_element["name"]
+                cube_target = join_element["name"]
 
+                # The non-target cube referenced in sql_on is the LEFT side
+                # of this hop. Cube wants the join declared on that cube.
                 joined_cubes = [
                     cube
                     for cube in get_cube_names_from_join_condition(
                         join_element["sql_on"]
                     )
-                    if cube != cube_right
+                    if cube != cube_target
                 ]
-                if joined_cubes:
-                    if "from" in join_element:
-                        cube = {
-                            "name": cube_right,
+                if not joined_cubes:
+                    continue
+                cube_left = joined_cubes[0]
+
+                # `from:` in a LookML join creates an aliased view that
+                # extends the source; emit it as an extending cube so the
+                # target name resolves before we attach the join.
+                if "from" in join_element:
+                    cube_def["cubes"].append(
+                        {
+                            "name": cube_target,
                             "extends": join_element["from"],
                             "shown": False,
                         }
-                        cube_def["cubes"].append(cube)
-                    else:
-                        cube = get_cube_from_cube_def(cube_def, cube_right)
-                        if not cube:
-                            console.print(
-                                f'Cube referenced in explores not found: {join_element["name"]}'
-                            )
-                            continue
-
-                    join_condition = join_element["sql_on"]
-
-                    if "joins" not in cube:
-                        cube["joins"] = []
-
-                    cube["joins"].append(
-                        {
-                            "name": joined_cubes[0],
-                            "sql": join_condition,
-                            "relationship": join_element["relationship"],
-                        }
                     )
+
+                cube = get_cube_from_cube_def(cube_def, cube_left)
+                if not cube:
+                    console.print(
+                        f"Cube referenced in explores not found: {cube_left}"
+                    )
+                    continue
+
+                if "joins" not in cube:
+                    cube["joins"] = []
+
+                cube["joins"].append(
+                    {
+                        "name": cube_target,
+                        "sql": join_element["sql_on"],
+                        "relationship": join_element["relationship"],
+                    }
+                )
             except Exception:
                 console.print(
                     f"Error while parsing explore: {pformat(explore)}", style="bold red"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -11,6 +11,13 @@ from lkml2cube.parser.explores import parse_explores, generate_cube_joins
 rootdir = join(dirname(__file__), "samples")
 
 
+def _find_cube(cube_def, name):
+    for cube in cube_def.get("cubes", []):
+        if cube.get("name") == name:
+            return cube
+    return None
+
+
 class TestExamples:
     def setup_method(self):
         """Set up test fixtures."""
@@ -47,3 +54,93 @@ class TestExamples:
         assert (
             generated_yaml == cube_model
         ), "Generated YAML does not match the expected YAML"
+
+
+class TestJoinDirection:
+    """Joins from an explore must land on the explore's base cube, with the
+    LookML relationship preserved verbatim.
+
+    Per Cube docs (https://cube.dev/docs/product/data-modeling/reference/joins):
+
+        > The join does not need to be defined on both cubes, but the
+        > definition can affect the join direction.
+        > The cube which defines the join serves as a main table.
+
+    The explore name in LookML *is* the base view — queries run from there,
+    so the join must be declared on that cube to keep it as the main (LEFT)
+    table in the generated SQL. Declaring on the joined-target cube with the
+    same relationship value silently flips cardinality.
+    """
+
+    def setup_method(self):
+        from lkml2cube.parser import loader
+        loader.visited_path.clear()
+
+    def _build(self):
+        # The fixture's `include: "/views/*.view.lkml"` is relative to the
+        # LookML project root (`tests/samples/lkml`), not the test samples
+        # root — same Looker convention that the model files use.
+        lkml_rootdir = join(rootdir, "lkml")
+        file_path = join(lkml_rootdir, "explores/orders_summary.model.lkml")
+        lookml_model = file_loader(file_path, lkml_rootdir)
+        assert lookml_model is not None, "fixture failed to load"
+        cube_def = parse_view(lookml_model, raise_when_views_not_present=False)
+        return generate_cube_joins(cube_def, lookml_model)
+
+    def test_one_to_many_lands_on_explore_base_cube(self):
+        # explore: orders { join: line_items { relationship: one_to_many ... } }
+        # Forward-side emit: cubes.orders.joins must contain line_items, rel one_to_many.
+        cube_def = self._build()
+        orders = _find_cube(cube_def, "orders")
+        assert orders is not None
+        joins = {j["name"]: j for j in orders.get("joins") or []}
+        assert "line_items" in joins, (
+            f"orders.joins missing line_items; got {list(joins)}"
+        )
+        assert joins["line_items"]["relationship"] == "one_to_many"
+
+    def test_join_lands_on_sql_on_left_side_not_explore_base(self):
+        # explore: orders { join: products { relationship: many_to_one
+        #   sql_on: ${line_items.product_id} = ${products.id} } }
+        # The sql_on references line_items, not orders — meaning the hop is
+        # line_items → products, even though the join is declared inside
+        # `explore: orders`. Cube's join graph uses Dijkstra to traverse, so
+        # an `orders` query needing `products` walks orders→line_items→products.
+        # Declaring the products join on `orders` would generate a wrong SQL
+        # join because there's no orders.product_id column.
+        cube_def = self._build()
+        line_items = _find_cube(cube_def, "line_items")
+        assert line_items is not None
+        joins = {j["name"]: j for j in line_items.get("joins") or []}
+        assert "products" in joins, (
+            f"line_items.joins missing products; got {list(joins)}"
+        )
+        assert joins["products"]["relationship"] == "many_to_one"
+
+    def test_separate_explore_writes_to_its_own_base(self):
+        # The fixture also has: explore: line_items { join: orders {...},
+        #   join: products {...} }. Those joins must land on cubes.line_items,
+        # not on cubes.orders / cubes.products.
+        cube_def = self._build()
+        line_items = _find_cube(cube_def, "line_items")
+        assert line_items is not None
+        join_names = {j["name"] for j in line_items.get("joins") or []}
+        assert {"orders", "products"} <= join_names, (
+            f"line_items.joins missing one of orders/products; got {join_names}"
+        )
+
+    def test_target_cube_does_not_receive_inverse_join(self):
+        # Regression guard: previously every explore-join was written to the
+        # target cube with the LookML relationship copied verbatim, producing
+        # cubes.line_items.joins.orders with relationship one_to_many — the
+        # uninverted cardinality from the wrong side. The fix removes that
+        # write entirely; the inverse-direction join only appears if a
+        # separate explore declares it (here `explore: line_items` does, so
+        # cubes.line_items.joins.orders exists at many_to_one, which is fine).
+        cube_def = self._build()
+        line_items = _find_cube(cube_def, "line_items")
+        assert line_items is not None
+        joins = {j["name"]: j for j in line_items.get("joins") or []}
+        # Only one entry pointing at orders, with the relationship from the
+        # line_items explore (many_to_one), not the orders explore's value.
+        assert joins.get("orders", {}).get("relationship") == "many_to_one"


### PR DESCRIPTION
## Problem

`generate_cube_joins` emits every LookML explore join on the **target** cube (the cube named after `join: <name>`), copying the LookML relationship value verbatim.

Cube's [join docs](https://cube.dev/docs/product/data-modeling/reference/joins) say "the cube which defines the join serves as a main table" — i.e. it becomes the LEFT side of the LEFT JOIN — and the relationship value describes cardinality from that cube outward. Because LookML's `relationship:` is written from the explore's perspective, copying it onto the target cube silently flips cardinality on the receiving side.

Example. LookML:

```lookml
explore: orders {
  join: customers {
    sql_on: ${orders.customer_id} = ${customers.id} ;;
    relationship: many_to_one
  }
}
```

Generated today (`customers` cube):

```yaml
cubes:
- name: customers
  joins:
  - name: orders
    relationship: many_to_one   # ← describes customers from orders' POV; wrong cardinality
    sql: ${orders.customer_id} = ${customers.id}
```

When two explores describe the same pair in opposite directions, both writes land on the same cube and stomp each other; in practice the result is inverted cardinality on at least one side.

## Fix

Emit each join on the cube that appears alongside the target in `sql_on` (the LEFT side of the hop), keeping the LookML relationship verbatim:

```yaml
cubes:
- name: orders
  joins:
  - name: customers
    relationship: many_to_one   # ← cardinality from orders outward, matches LookML
    sql: ${orders.customer_id} = ${customers.id}
```

Cube traverses joins bidirectionally via Dijkstra, so a single-sided declaration is sufficient — emitting on both sides would produce redundant joins.

The LEFT side derives from `sql_on`, not the explore name, which is the correct interpretation for multi-hop chains where `join:` declarations transitively reach a target through an intermediate view.

## Coverage

New `TestJoinDirection` class in `tests/test_e2e.py` using the existing `orders_summary.model.lkml` fixture. Four direction-asserting tests pass after the fix and fail before it. Full suite goes from 73 → 78 passing.

## Real-world validation

Ran on a 354-explore-join LookML model (nurturecloud, ~150 views):

| | Before | After |
|---|---|---|
| `ok` (forward, rel preserved) | 0 | 59 |
| `inverse_ok` (entry on target side, rel correctly inverted) | 0 | 5 |
| `mismatch` (entry exists, wrong cardinality) | 100 | 6 |
| `not_emitted` (no entry on either side) | 254 | 284 |

The remaining 6 mismatches are LookML source inconsistencies (same relationship declared with conflicting cardinalities in different explores — e.g. `property→agent: one_to_one` in one explore, `agent→property: one_to_many` in another). The `not_emitted` increase is because multi-hop joins (where `sql_on`'s LEFT side isn't the explore name) now correctly land on the intermediate cube rather than on the explore base. Both reflect correct behaviour, not regressions.

## Scope notes

- `many_to_many` (which LookML supports but [Cube's join docs don't list](https://cube.dev/docs/product/data-modeling/reference/joins#relationship)) is left untouched — still emitted verbatim. Mapping it to a junction-cube pattern is a separate concern.
- Behaviour for `join: foo { from: bar }` is preserved: the aliased cube is still created; only the cube that receives the `joins:` entry changes.